### PR TITLE
Fix cache.http_max_store_size config

### DIFF
--- a/src/com/facebook/buck/artifact_cache/ArtifactCaches.java
+++ b/src/com/facebook/buck/artifact_cache/ArtifactCaches.java
@@ -690,6 +690,7 @@ public class ArtifactCaches implements ArtifactCacheFactory, AutoCloseable {
             .setHttpFetchExecutorService(httpFetchExecutorService)
             .setErrorTextTemplate(cacheDescription.getErrorMessageFormat())
             .setErrorTextLimit(cacheDescription.getErrorMessageLimit())
+            .setMaxStoreSizeBytes(cacheDescription.getMaxStoreSize())
             .build());
   }
 


### PR DESCRIPTION
Fixes [http_max_store_size](https://buck.build/files-and-dirs/buckconfig.html#cache.http_max_store_size).