### PR TITLE
Add is_main_run_destination property to Apple Binary

### DIFF
--- a/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
+++ b/src/com/facebook/buck/apple/AppleNativeTargetDescriptionArg.java
@@ -31,6 +31,8 @@ public interface AppleNativeTargetDescriptionArg
   @Value.NaturalOrder
   ImmutableSortedMap<String, ImmutableMap<String, String>> getConfigs();
 
+  Optional<Boolean> getIsMainRunDestination();
+
   Optional<String> getHeaderPathPrefix();
 
   @Value.Default

--- a/src/com/facebook/buck/apple/xcode/xcodeproj/PBXTarget.java
+++ b/src/com/facebook/buck/apple/xcode/xcodeproj/PBXTarget.java
@@ -31,6 +31,7 @@ public abstract class PBXTarget extends PBXProjectItem {
   @Nullable private String productName;
   @Nullable private PBXFileReference productReference;
   @Nullable private ProductType productType;
+  @Nullable private Boolean isMainRunDestination;
 
   public PBXTarget(String name, AbstractPBXObjectFactory objectFactory) {
     this.name = name;
@@ -86,6 +87,10 @@ public abstract class PBXTarget extends PBXProjectItem {
     this.productType = productType;
   }
 
+  @Nullable
+  public Boolean getIsMainRunDestination() { return isMainRunDestination; };
+
+  public void setIsMainRunDestination(@Nullable Boolean isMainRunDestination) { this.isMainRunDestination = isMainRunDestination; }
   @Override
   public String isa() {
     return "PBXTarget";

--- a/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/ProjectGenerator.java
@@ -2070,6 +2070,8 @@ public class ProjectGenerator {
       // Use Core Data models from immediate dependencies only.
       addCoreDataModelsIntoTarget(appleTargetNode.get(), targetGroup.get());
       addSceneKitAssetsIntoTarget(appleTargetNode.get(), targetGroup.get());
+
+      target.setIsMainRunDestination(appleTargetNode.get().getConstructorArg().getIsMainRunDestination().orElse(false));
     }
 
     if (bundle.isPresent()

--- a/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
+++ b/src/com/facebook/buck/features/apple/project/WorkspaceAndProjectGenerator.java
@@ -1163,8 +1163,13 @@ public class WorkspaceAndProjectGenerator {
 
       // attempt to find a suitable primary target inside the project's targets
       // the primary target is used by SchemeGenerator for launch/profile actions
+
       Optional<PBXTarget> primaryTarget = Optional.empty();
       for (PBXTarget target : project.getTargets()) {
+        if (target.getIsMainRunDestination()) {
+          primaryTarget = Optional.of(target);
+          break;
+        }
         String targetName = target.getName().toLowerCase();
         if (targetName.endsWith("app") && !targetName.contains("test")) {
           primaryTarget = Optional.of(target);


### PR DESCRIPTION
If this property is true, the Apple Binary will be selected as default runnable executable in Xcode.

E.g.
BUCK file:
`apple_binary(
    name = "iFoodAppBinary",
    is_main_run_destination = True, ...)`

Results in:

![Captura de Tela 2020-10-22 às 20 15 52](https://user-images.githubusercontent.com/6426451/96939426-6912da00-14a3-11eb-978e-5ea8339bc982.png)
